### PR TITLE
Adding Mock Router Decorator

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,18 @@
+<style>
+.my-wrapper {
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 960px;
+  align-items: center;
+  /* justify-content: center; */
+  font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular", "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif
+}
+
+.intro {
+  flex-basis: 100%;
+}
+
+h1 {
+  flex-basis: 100%;
+}
+</style>

--- a/examples/components/routerViewWrapper.vue
+++ b/examples/components/routerViewWrapper.vue
@@ -25,6 +25,7 @@ export default defineComponent({
   },
   setup () {
     const route = useRoute()
+
     const fullPath = computed(() => route.fullPath )
 
     return { fullPath }
@@ -34,23 +35,6 @@ export default defineComponent({
 
 
 <style>
-.my-wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  max-width: 960px;
-  align-items: center;
-  /* justify-content: center; */
-  font-family: "Nunito Sans", -apple-system, ".SFNSText-Regular", "San Francisco", BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif
-}
-
-.intro {
-  flex-basis: 100%;
-}
-
-h1 {
-  flex-basis: 100%;
-}
-
 /* router transition CSS */
 .slide-fade-enter-active {
   transition: all .5s .5s ease-out;

--- a/examples/mockRouter.stories.ts
+++ b/examples/mockRouter.stories.ts
@@ -1,0 +1,96 @@
+import { mockRouter } from '../dist/esm'
+
+export default {
+  title: 'Mock Router',
+  argTypes: {
+    path: {
+      control: 'text',
+      defaultValue: '/',
+    },
+    some_meta: {
+      control: 'select',
+      options: ['true', 'false'],
+      defaultValue: 'true',
+    },
+    some_param: {
+      control: 'select',
+      options: ['true', 'false'],
+      defaultValue: 'false',
+    },
+    some_query: {
+      control: 'select',
+      options: ['true', 'false'],
+      defaultValue: 'false',
+    },
+  }
+};
+
+export const Default = () => ({
+  /* create template and pass Storybook args to <router-view> using props */
+  template: `
+    <div class="my-wrapper">
+      <div>
+        <h2>$route:</h2>
+        <pre>&lt;pre&gt;&#123;&#123;&nbsp;&sect;route&nbsp;&#125;&#125;&lt;/pre&gt;</pre>
+        <pre>{{ $route }}</pre>
+      </div>
+    </div>
+  `
+})
+
+Default.decorators = [
+  mockRouter({
+    meta: ['some_meta'],
+    params: ['some_param'],
+    query: ['some_query']
+  })
+]
+
+export const DynamicTemplate = () => ({
+  /* create template and pass Storybook args to <router-view> using props */
+  template: `
+    <div class="my-wrapper">
+      <div>
+        <h3 style="margin-top: 2em">Example dynamic template from <code>$route.meta.some_meta</code></h3>
+        
+        <template v-if="$route.meta.some_meta === 'true'">
+          <code>some_meta</code> is true!
+        </template>
+        <template v-else>
+          <code>some_meta</code> is not true!
+        </template>
+      </div>
+    </div>
+  `
+})
+
+DynamicTemplate.decorators = [
+  mockRouter({
+    meta: ['some_meta'],
+    params: ['some_param'],
+    query: ['some_query']
+  })
+]
+
+export const ProgramaticNavigation = () => ({
+  /* create template and pass Storybook args to <router-view> using props */
+  template: `
+    <div class="my-wrapper">
+      <div>
+        <button @click="$router.push('/some-route')" style="margin-bottom: 1em">Push</button><br/>
+        <button @click="$router.replace('/some-route')" style="margin-bottom: 1em">Replace</button><br/>
+        <button @click="$router.go(1)" style="margin-bottom: 1em">Go</button><br/>
+        <button @click="$router.back()" style="margin-bottom: 1em">Back</button><br/>
+        <button @click="$router.forward()">Forward</button>
+      </div>
+    </div>
+  `
+})
+
+ProgramaticNavigation.decorators = [
+  mockRouter({
+    meta: ['some_meta'],
+    params: ['some_param'],
+    query: ['some_query']
+  })
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ if (module && module.hot && module.hot.decline) {
 }
 
 import vueRouter from './withVueRouter'
-
+import mockRouter from './withMockRouter'
 // make it work with --isolatedModules
 export default vueRouter;
+export { mockRouter }

--- a/src/withMockRouter.ts
+++ b/src/withMockRouter.ts
@@ -1,0 +1,67 @@
+
+import { app } from "@storybook/vue3";
+import { makeDecorator } from "@storybook/addons";
+import { LegacyStoryFn, StoryContext } from "@storybook/addons/dist/ts3.9/types";
+import { action } from '@storybook/addon-actions';
+
+function getFromArgs(args: { [key: string]: any }, options: Array<string>) {
+  let filtered : { [key: string]: any } = {}
+  options.forEach((option) => {
+    filtered = { ...filtered, [option]: args[option] }
+  })
+
+  return filtered
+}
+
+/**
+ * Add a vue router instance to Storybook stories
+ * @param routes (optional) custom routes for story
+ * @param options (optional) custom options
+ *
+ * @remarks
+ *
+ * If there is a previously initialized story using vue-router and you wish to use `beforeEach` to apply global router guards via `options` param,
+ * we must reload the story in order to apply the global route guards, this can have a minor performance impact.
+ */
+export const withMockRouter = (
+  options: { meta?: Array<string>, params?: Array<string>, query?: Array<string> }
+) => makeDecorator({
+  name: 'withMockRouter',
+  parameterName: 'withMockRouter',
+
+  wrapper: (storyFn: LegacyStoryFn, context: StoryContext) => {
+    /* check if there is an existing router */
+    const existingRouter = app.config.globalProperties.$router
+    const existingRoute = app.config.globalProperties.$route
+    
+    /* if vue-router is already initialized we refresh the page to ensure full (non-mocked) vue-router can be initialized */
+    const forceReload = (existingRouter && existingRouter.isMocked !== true) && (existingRoute && existingRoute.isMocked !== true)
+    if (forceReload) {
+      existingRouter.go(0)
+      return
+    } else {
+      app.config.globalProperties.$router = {
+        isMocked: true, // !IMPORTANT this line is required to ensure the full vue-router implementation can initialize
+        push: (location: string) => { action('$router.push()')(location) },
+        replace: (location: string) => { action('$router.replace()')(location) },
+        go: (n: number) => { action('$router.go()')(n) },
+        back: () => { action('$router.back()')('back') },
+        forward: () => { action('$router.forward()')('forward') },
+      }
+      app.config.globalProperties.$route = {
+        isMocked: true, // !IMPORTANT this line is required to ensure the full vue-router implementation can initialize
+        path: context.args.path || '/',
+        fullPath: `/#${context.args.path}`,
+        name: context.args.name || 'home',
+        meta: options.meta ? getFromArgs(context.args, options.meta) : {},
+        params: options.params ? getFromArgs(context.args, options.params) : {},
+        query: options.query ? getFromArgs(context.args, options.query) : {},
+      }
+    }
+
+    /* return the storybook story */
+    return storyFn(context);
+  }
+})
+  
+export default withMockRouter;

--- a/src/withVueRouter.ts
+++ b/src/withVueRouter.ts
@@ -76,7 +76,8 @@ export const withVueRouter = (
 
     /* check if there is an existing router */
     const existingRouter = app.config.globalProperties.$router
-    if (!existingRouter) {
+    const existingRoute = app.config.globalProperties.$route
+    if ((!existingRouter || existingRouter.isMocked === true) && (!existingRoute || existingRoute.isMocked === true)) {
       /* create vue router */
       router = createRouter({
         history: createWebHashHistory(),
@@ -94,7 +95,6 @@ export const withVueRouter = (
 
       /* reset routes (remove old / add new) */
       resetRoutes(router, routes)
-
       /* setup optional global router guards (if provided and there is an existing router this will force a page reload) */
       globalRouterGuardFn(existingRouter, options?.beforeEach, true)
     }


### PR DESCRIPTION
- Adding a simple `mockRouter` decorator to mock `$route` and `$router` for basic usage.
- Moved some global Storybook styles to `.storybook/preview-head.html`

See `mockRouter` story examples: https://github.com/NickMcBurney/storybook-vue3-router/blob/6b6761c4e1c581dc7019ae305b61e96a82f03e41/examples/mockRouter.stories.ts