### PR TITLE
Fix docs stories

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,9 +1,6 @@
 module.exports = {
   stories: ["../examples/**/*.stories.mdx", "../examples/**/*.stories.@(js|jsx|ts|tsx)"],
   addons: ["../preset.js", "@storybook/addon-essentials"],
-  docs: {
-    autodocs: false
-  },
   framework: {
     name: "@storybook/vue3-vite",
     options: {}

--- a/examples/basicExamples.stories.ts
+++ b/examples/basicExamples.stories.ts
@@ -5,6 +5,7 @@ import routerViewWrapper from './components/routerViewWrapper.vue'
 export default {
   title: 'Basic Router View Wrapper',
   component: routerViewWrapper,
+  tags: ['autodocs'],
 }
 
 /**

--- a/src/withMockRouter.ts
+++ b/src/withMockRouter.ts
@@ -1,8 +1,7 @@
 
-import { setup, Decorator } from '@storybook/vue3'
-import { App } from 'vue';
+import { Decorator } from '@storybook/vue3'
+import { getCurrentInstance } from 'vue';
 import { action } from '@storybook/addon-actions'
-import type { StoryContext, StoryFn } from '@storybook/types'
 
 import type {
   Router,
@@ -29,16 +28,9 @@ export function withMockRouter (
     /* optional: router options - used to pass `initialRoute` value, `beforeEach()` navigation guard methods and vue-router `createRouter` options */
     options: { meta?: Array<string>, params?: Array<string>, query?: Array<string> }
 ): Decorator {
-  let app: App
-  let ctx: StoryContext
-
-  setup((setupApp: App, context: StoryContext) => {
-    app = setupApp
-    ctx = context
-  })
-
-  return () => ({
+  return (_, ctx) => ({
     setup () {
+      const { app } = getCurrentInstance()!.appContext
       const existingRouter = app.config.globalProperties.$router as MockRouter
       const existingRoute = app.config.globalProperties.$route as MockRoute
       

--- a/src/withVueRouter.ts
+++ b/src/withVueRouter.ts
@@ -1,6 +1,5 @@
-import { setup, Decorator } from '@storybook/vue3'
-import { App } from 'vue';
-import type { StoryContext, StoryFn } from '@storybook/types'
+import { Decorator } from '@storybook/vue3'
+import { getCurrentInstance } from 'vue';
 
 import {
   createRouter,
@@ -38,14 +37,10 @@ export function withVueRouter (
     vueRouterOptions?: RouterOptions;
   }
 ): Decorator {
-  let app: App
-
-  setup((setupApp: App) => {
-    app = setupApp
-  })
-
   return () => ({
     setup () {
+        const { app } = getCurrentInstance()!.appContext
+
         /* setup router var */
         let router
 


### PR DESCRIPTION
Fixes issue caused by #55 mentioned in #54.

So the solution that worked for me to solve #54 wasn't taking into consideration the multiple apps that can be created in the "Docs" page of storybook. The following screenshots show the errors:

![Screenshot from 2023-11-14 14-45-40](https://github.com/NickMcBurney/storybook-vue3-router/assets/6027291/fcb17930-b322-43b7-8895-0ce489cea344)

![Screenshot from 2023-11-14 14-45-49](https://github.com/NickMcBurney/storybook-vue3-router/assets/6027291/55a49370-a73f-463f-b1b7-b593dc43aa76)

To fix this, this PR avoids the use of `setup` from `@storybook/vue3` and instead uses `getCurrentInstance` from `vue` in setup function to get the app instance.

![Screenshot from 2023-11-14 14-47-07](https://github.com/NickMcBurney/storybook-vue3-router/assets/6027291/d4ff34c1-7190-46d0-a8dd-a14991db9bdf)

![Screenshot from 2023-11-14 14-46-52](https://github.com/NickMcBurney/storybook-vue3-router/assets/6027291/710c188a-2cdd-430e-b492-19f7e3f9c27b)

