### PR TITLE
fix: Don't limit @storybook/vue3 peer dependency to exactly 9.0.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "zx": "^1.15.2"
   },
   "peerDependencies": {
-    "@storybook/vue3": "9.0.18",
+    "@storybook/vue3": "9.x",
     "vue": "3.x",
     "vue-router": "4.x"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 dependencies:
   '@storybook/vue3':
-    specifier: 9.0.18
+    specifier: 9.x
     version: 9.0.18(storybook@9.0.18)(vue@3.5.18)
   vue-router:
     specifier: ^4.5.1
@@ -809,7 +809,7 @@ packages:
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@2.8.8)
       type-fest: 2.19.0
       vue: 3.5.18(typescript@5.8.3)
-      vue-component-type-helpers: 3.0.4
+      vue-component-type-helpers: 3.0.5
 
   /@testing-library/dom@10.4.0:
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -2273,8 +2273,8 @@ packages:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
     dev: true
 
-  /vue-component-type-helpers@3.0.4:
-    resolution: {integrity: sha512-WtR3kPk8vqKYfCK/HGyT47lK/T3FaVyWxaCNuosaHYE8h9/k0lYRZ/PI/+T/z2wP+uuNKmL6z30rOcBboOu/YA==}
+  /vue-component-type-helpers@3.0.5:
+    resolution: {integrity: sha512-uoNZaJ+a1/zppa/Vgmi8zIOP2PHXDN2rT8NyF+zQRK6ZG94lNB9prcV0GdLJbY9i9lrD47JOVIH92SaiA7oJ1A==}
 
   /vue-docgen-api@4.79.2(vue@3.5.18):
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}


### PR DESCRIPTION
The current configuration is causing the below error when using any other version of `@storybook/vue3` than `v9.0.18`.

> You are currently using Storybook 9.1.0 but you have packages which are incompatible with it:
> - [storybook-vue3-router@6.0.0](mailto:storybook-vue3-router@6.0.0) which depends on 9.0.18